### PR TITLE
Renamed Template Database to Findings Database

### DIFF
--- a/views/layout.haml
+++ b/views/layout.haml
@@ -53,7 +53,7 @@
             %ul.nav{"class" => "pull-right padded"}
               - if is_administrator?
                 %li
-                  %a{:href => "/master/findings"} Template Database
+                  %a{:href => "/master/findings"} Findings Database
                 %li
                   %a{:href => "/admin/"} Administration
               %li


### PR DESCRIPTION
Changed link label from Template to Findings as the link sends you to the findings database. 
