### PR TITLE
Add date formatting

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
     "ssl_certificate":"./cert.pem",
     "ssl_key":"key.pem",
     "ldap":"false",
+  	"date_format": "%-m/%-d/%Y",
     "ldap_domain":"",
     "ldap_dc":"",
     "dread":false,  //DREAD risk scoring not used by default

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
     "ssl_certificate":"./cert.pem",
     "ssl_key":"key.pem",
     "ldap":"false",
-  	"date_format": "%-m/%-d/%Y",
+    "date_format": "%-m/%-d/%Y",
     "ldap_domain":"",
     "ldap_dc":"",
     "dread":false,  //DREAD risk scoring not used by default

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -1407,7 +1407,17 @@ get '/report/:id/generate' do
   plugins_xml = PluginNotifier.instance.notify_report_generated(@report)
 
   # we bring all xml together
-  report_xml = "<report>#{CGI.unescapeHTML(@report.to_xml)}#{udv}#{findings_xml}#{udo_xml}#{services_xml}#{hosts_xml}#{all_appendices_xml}#{plugins_xml}</report>"
+
+  # To adjust the date format we change it manually here:
+  date_format = config_options['date_format']
+  if !@report.assessment_start_date.empty?
+    @report.assessment_start_date = Date.parse(@report.assessment_start_date).strftime(date_format)
+  end
+  if !@report.assessment_end_date.empty?
+    @report.assessment_end_date = Date.parse(@report.assessment_end_date).strftime(date_format)
+  end
+  # Here we replace all variables in the template with variables from the database
+  report_xml = "<report>#{@report.to_xml}#{udv}#{findings_xml}#{udo_xml}#{services_xml}#{hosts_xml}</report>"
   noko_report_xml = Nokogiri::XML(report_xml)
   #no use to go on with report generation if report XML is malformed
   if !noko_report_xml.errors.empty?


### PR DESCRIPTION
I added a way to change the following date variables:

- assessment_start_date
- assessment_emd_date

The config.json now has a date_format variable that takes ISO 8601 formats:

https://apidock.com/ruby/DateTime/strftime

This could be extended to logging if wanted. My code is crude. I simply check to see if the variable have been set, and if they have been I modify them using strtime just before they are added to the document. Works well enough. It also shouldn't mess with anything since I only change the date before it is entered into the word document. However, I could see a situation where someone messes up the ISO date format or adds special chars that cause the word doc to break down. I had a specif need and wrote this to scratch it. It might not meet all the needs. I am only making a pull request to share in what I did. 